### PR TITLE
added link to css-spinners-react

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 ## Single-element CSS
 
 - CSS Spinners by John Long ([Source](https://github.com/jlong/css-spinners))
+- css-spinners-react (React adaptation of CSS Spinners by John Long) by Adam Wanninger ([Source](https://github.com/ajwann/css-spinners-react))
 - Loaders Kit by Viduthalai Mani ([Demo](http://cssdeck.com/labs/loaderskit))
 - Single Element CSS Spinners by Luke Haas ([Demo](https://projects.lukehaas.me/css-loaders/)) ([Source](https://github.com/lukehaas/css-loaders))
 - CSS Loading Spinners by Harold Soto ([Demo & Source](https://codepen.io/bernethe/pen/dorozd))


### PR DESCRIPTION
Hi, I've created a nice React adaptation of John Longs popular [CSS-Spinners library](https://github.com/jlong/css-spinners), and I would love to list it here. 

Here is my new React component package:
https://github.com/ajwann/css-spinners-react